### PR TITLE
Replace room illustrations with photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,13 +381,8 @@
       <div class="rooms-grid">
         <!-- Room: Doble -->
         <article class="room-card" aria-labelledby="room-doble-title">
-          <div class="room-illus" role="img" aria-label="Ilustración decorativa de la Habitación Doble">
-            <svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
-              <rect x="0" y="0" width="600" height="200" rx="14" fill="#FFF5F2" stroke="#E9C1C6"/>
-              <rect x="40" y="90" width="520" height="40" rx="8" fill="#D17356" opacity=".25"/>
-              <rect x="60" y="80" width="160" height="50" rx="8" fill="#91AE9A" opacity=".35"/>
-              <rect x="380" y="80" width="160" height="50" rx="8" fill="#91AE9A" opacity=".35"/>
-            </svg>
+          <div class="room-illus">
+            <img src="images/double.png" alt="Habitación doble de Posada Don Gustavo con cama queen" loading="lazy" />
           </div>
           <h3 id="room-doble-title">Doble</h3>
           <div class="pill-row" aria-label="Características">
@@ -407,12 +402,8 @@
 
         <!-- Room: Suite Familiar -->
         <article class="room-card" aria-labelledby="room-familiar-title">
-          <div class="room-illus" role="img" aria-label="Ilustración decorativa de la Suite Familiar">
-            <svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
-              <rect x="0" y="0" width="600" height="200" rx="14" fill="#F6FBF7" stroke="#d9e7dd"/>
-              <rect x="60" y="70" width="240" height="80" rx="10" fill="#91AE9A" opacity=".4"/>
-              <rect x="320" y="85" width="220" height="50" rx="8" fill="#D17356" opacity=".32"/>
-            </svg>
+          <div class="room-illus">
+            <img src="images/familiar.png" alt="Suite familiar de Posada Don Gustavo con dos ambientes" loading="lazy" />
           </div>
           <h3 id="room-familiar-title">Suite Familiar</h3>
           <div class="pill-row" aria-label="Características">
@@ -432,12 +423,8 @@
 
         <!-- Room: Económica -->
         <article class="room-card" aria-labelledby="room-economica-title">
-          <div class="room-illus" role="img" aria-label="Ilustración decorativa de la Habitación Económica">
-            <svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
-              <rect x="0" y="0" width="600" height="200" rx="14" fill="#FFFFFF" stroke="#E9C1C6"/>
-              <rect x="70" y="90" width="460" height="40" rx="8" fill="#D17356" opacity=".2"/>
-              <circle cx="120" cy="100" r="16" fill="#91AE9A" opacity=".35"/>
-            </svg>
+          <div class="room-illus">
+            <img src="images/ecnomica.png" alt="Habitación económica de Posada Don Gustavo con cama matrimonial" loading="lazy" />
           </div>
           <h3 id="room-economica-title">Económica</h3>
           <div class="pill-row" aria-label="Características">


### PR DESCRIPTION
## Summary
- replace inline SVG placeholders in each room card with photographic images from the images directory
- retain existing layout while providing descriptive alt text and lazy-loading for the new images

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc16992840832d92253f9b1b328263